### PR TITLE
When using HEAD requests set the appropriate curl header to not wait …

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -399,6 +399,9 @@ class Request
 			if ($method === Method::POST) {
 				curl_setopt(self::$handle, CURLOPT_POST, true);
 			} else {
+                 if ($method === Method::HEAD) {
+                    curl_setopt(self::$handle, CURLOPT_NOBODY, true);
+                 }
 				curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
 			}
 


### PR DESCRIPTION
…for a response body. See http://www.php.net/manual/en/function.curl-setopt.php on CURLOPT_NOBODY.